### PR TITLE
mozcommitbuilder uses pulse but it is not declared in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,25 @@
 from setuptools import setup, find_packages
-#from distutils.core import setup
-#from setuptools import setup, find_packages
+
+deps = ['pulsebuildmonitor',
+        'mozrunner >= 2.5.4',
+        'httplib2 >= 0.6.0',
+        'simplejson']
+
 setup(name='mozcommitbuilder',
-      version='0.4.7',
+      version='0.4.8',
       description ="""Regression finder using Mozilla central repo""",
       author="Sam Liu",
       author_email="sam@ambushnetworks.com",
-      url='http://github.com/samliu/mozcommitbuilder',
+      url='http://github.com/mozilla/mozcommitbuilder',
       license='MPL 1.1/GPL 2.0/LGPL 2.1',
       packages=find_packages(exclude=['legacy']),
       entry_points="""
           [console_scripts]
           mozcommitbuilder = mozcommitbuilder:buildercli
         """,
-      install_requires = ['mozrunner >= 2.5.4', 'httplib2 >= 0.6.0', 'simplejson'],
+      install_requires = deps,
       classifiers=['Development Status :: 4 - Beta',
                    'Intended Audience :: Developers',
                    'Operating System :: OS Independent'
                   ]
-
       )


### PR DESCRIPTION
https://github.com/mozilla/mozcommitbuilder/issues/4

pypi should also be updated.  
